### PR TITLE
FullPipelineTest.testCreateNewPipeline error should be fixed

### DIFF
--- a/src/test/java/school/redrover/FullPipelineTest.java
+++ b/src/test/java/school/redrover/FullPipelineTest.java
@@ -13,7 +13,7 @@ import school.redrover.common.BaseTest;
 
 import java.time.Duration;
 
-@Ignore
+
 public class FullPipelineTest extends BaseTest {
     @Test
     public void testCreateNewPipeline() {
@@ -27,7 +27,7 @@ public class FullPipelineTest extends BaseTest {
 
         wait.until(ExpectedConditions.elementToBeClickable(By.name("Submit"))).click();
 
-        WebElement pipelineTitle = wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//h1")));
+        WebElement pipelineTitle = wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//h1[contains(@class, 'job-index-headline')]")));
         Assert.assertEquals(pipelineTitle.getText(), "Test Pipeline");
     }
 

--- a/src/test/java/school/redrover/FullPipelineTest.java
+++ b/src/test/java/school/redrover/FullPipelineTest.java
@@ -7,7 +7,6 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import org.testng.Assert;
-import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 import school.redrover.common.BaseTest;
 


### PR DESCRIPTION
My previous test caused FullPipelineTest.testCreateNewPipeline:29 expected [Test Pipeline] but found [Configure]

Fixed an issue where the test was verifying the title of the wrong page: adjusted the XPath selector to ensure the correct pipeline title is checked after creation.

Please take a look if it can actually fix the problem