### PR TITLE
Fix test testBuildAfterOtherProjectsAreBuiltOptionDisplaysField

### DIFF
--- a/src/test/java/school/redrover/FreestyleProjectConfigurationBuildTriggersTest.java
+++ b/src/test/java/school/redrover/FreestyleProjectConfigurationBuildTriggersTest.java
@@ -1,7 +1,6 @@
 package school.redrover;
 
 import org.testng.Assert;
-import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 import school.redrover.common.BaseTest;
 import school.redrover.page.freestyle.FreestyleConfigurationPage;
@@ -84,13 +83,13 @@ public class FreestyleProjectConfigurationBuildTriggersTest extends BaseTest {
         Assert.assertEquals(freestyleConfigurationPage.getTriggerInfoText(), EXPECTED_TRIGGER_INFO_TEXT);
     }
 
-    @Ignore//FreestyleProjectConfigurationBuildTriggersTest.testBuildAfterOtherProjectsAreBuiltOptionDisplaysField:104 » NullPointer Cannot invoke "String.equals(Object)" because the https://github.com/RedRoverSchool/JenkinsQA_Java_2025_spring/actions/runs/14732685957/job/41350713407?pr=1586
+
     @Test
     public void testBuildAfterOtherProjectsAreBuiltOptionDisplaysField() {
 
         //Actions
         FreestyleConfigurationPage freestyleConfigurationPage = new HomePage(getDriver())
-                .createJob()
+                .clickNewItemOnLeftSidePanel()
                 .sendItemName(PROJECT_NAME)
                 .selectFreestyleAndClickOk()
                 .scrollToTriggersItem()


### PR DESCRIPTION
ER_02.004.01 | FreestyleProjectConfigurationBuildTriggersTest > NullPointer Cannot invoke "String.equals(Object)"